### PR TITLE
Update ISO timestamp format

### DIFF
--- a/Assets/Scripts/xStatement.cs
+++ b/Assets/Scripts/xStatement.cs
@@ -29,7 +29,7 @@ public class XStatement {
 			verb.toJSONstring() + ", " + 
 			obj.toJSONstring() + 
 			result.ToJSONstring() + 
-			", \"timestamp\": \"" + timestamp.ToString("s", System.Globalization.CultureInfo.InvariantCulture) + "\"" +
+			", \"timestamp\": \"" + timestamp.ToString("o", System.Globalization.CultureInfo.InvariantCulture) + "\"" +
 			"}";
 	}
 }


### PR DESCRIPTION
## Add milliseconds due to xAPI requirement

According to the [xAPI Spec](https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Data.md#45-iso-8601-timestamps):

> A Timestamp MUST preserve precision to at least milliseconds (3 decimal points beyond seconds).

Some LRS providers (SCORM Cloud) may accept and convert by adding the 3 required decimal points, but some (Learning Locker v2) will fail to accept them.

So this original format (using "s"):
`timestamp.ToString("s", System.Globalization.CultureInfo.InvariantCulture)`

will result in this:
`2017-12-09T16:44:37`

whereas this (using "o"):
`timestamp.ToString("o", System.Globalization.CultureInfo.InvariantCulture)`

will result in this:
`2017-12-09T16:44:37.8900494Z`

---

I'll admit to not knowing much about System dates in Unity/C#/.NET but Googling revealed this Stack Overflow article to find this solution:

https://stackoverflow.com/questions/114983/given-a-datetime-object-how-do-i-get-an-iso-8601-date-in-string-format

In some cases, where the statement is sent at the time of the event, eliminating the timestamp from the sent statement will allow the LRS to create the timestamp at the time of storage and be roughly accurate. However, if more accuracy is required manually creating the timestamp is still best.

Thanks @pguenthe , for your work on this!